### PR TITLE
fix: Incomplete URL scheme check in marked.js

### DIFF
--- a/org.eclipse.tm4e.markdown/marked.js/marked.js
+++ b/org.eclipse.tm4e.markdown/marked.js/marked.js
@@ -875,7 +875,7 @@ Renderer.prototype.link = function(href, title, text) {
     } catch (e) {
       return '';
     }
-    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0) {
+    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
       return '';
     }
   }


### PR DESCRIPTION
Fixes [https://github.com/eclipse-tm4e/tm4e/security/code-scanning/2](https://github.com/eclipse-tm4e/tm4e/security/code-scanning/2)

To fix the problem, we need to extend the URL scheme check to include `data:` in addition to `javascript:` and `vbscript:`. This will ensure that URLs with potentially harmful schemes are properly sanitized. The best way to fix this without changing existing functionality is to modify the condition on line 878 to also check for `data:` schemes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
