### PR TITLE
fix: IllegalArgumentException in Colorizer event processing.

### DIFF
--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/Colorizer.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/Colorizer.java
@@ -166,6 +166,13 @@ class Colorizer {
 			length = Math.min(length, damageRegion.getOffset() + damageRegion.getLength() - lastStart);
 			addStyleRange(presentation, lastStart, length, lastAttribute);
 			viewer.changeTextPresentation(presentation, false);
+		} catch (final IllegalArgumentException | BadLocationException ex) {
+			error = ex;
+			// These exceptions can be thrown if there is a delay running the tokenizer thread
+			// and the tokens become out of sync with the document line data.
+			// As this is an expected state, only log them if tracing is enabled.
+			if (TMUIPlugin.isLogTraceEnabled())
+				TMUIPlugin.logError(ex);
 		} catch (final Exception ex) {
 			error = ex;
 			TMUIPlugin.logError(ex);


### PR DESCRIPTION
The Colorizer should not process stale tokens if they go over the end of the line in the current document. This prevents IllegalArgumentException occurring when the Tokenizer thread runs slow or is delayed relative to the textChanged notification in the reconciler.

<!-- Before submitting a PR, please:
1. read the guidelines for contributions https://github.com/eclipse-tm4e/tm4e/blob/main/CONTRIBUTING.md
2. ensure you signed the Eclipse Contributor Agreement https://www.eclipse.org/projects/handbook/#contributing-eca
3. prefix the PR title with one of these semantic labels:
   - build:
   - ci:
   - chore:
   - docs:
   - fix:
   - feat:
   - refact:
   - revert:
   - perf:
   - style:
-->

