### PR TITLE
fix: do not log BadLocationException when colorizing from tokenizer thread

### DIFF
--- a/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/Colorizer.java
+++ b/org.eclipse.tm4e.ui/src/main/java/org/eclipse/tm4e/ui/text/Colorizer.java
@@ -76,7 +76,9 @@ class Colorizer {
 					final var region = new Region(doc.getLineOffset(range.fromLineNumber - 1), length);
 					colorize(region, docModel);
 				} catch (final BadLocationException ex) {
-					TMUIPlugin.logError(ex);
+					// This is an expected state, only log when tracing is enabled.
+					if (TMUIPlugin.isLogTraceEnabled())
+						TMUIPlugin.logError(ex);
 				}
 			}
 		}


### PR DESCRIPTION
tokenizer thread runs asynchronously to modifications to the document, so it is expected that the colorizer may throw BadLocationExceptions, and there is no need to log these
