### PR TITLE
feat: prompt user when attempting to toggle comments on a read-only file

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationMessages.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationMessages.java
@@ -87,6 +87,11 @@ public final class LanguageConfigurationMessages extends NLS {
 	public static String SelectLanguageConfigurationWizardPage_workspace_description;
 	public static String SelectLanguageConfigurationWizardPage_workspace_title;
 
+	public static String ToggleLineCommentHandler_ReadOnlyEditor_title;
+	public static String ToggleLineCommentHandler_ReadOnlyEditor_inputReadonly;
+	public static String ToggleLineCommentHandler_ReadOnlyEditor_fileReadonly;
+	public static String ToggleLineCommentHandler_ReadOnlyEditor_makingWritableFailed;
+
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, LanguageConfigurationMessages.class);
 	}

--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationMessages.properties
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/LanguageConfigurationMessages.properties
@@ -73,3 +73,8 @@ SelectLanguageConfigurationWizardPage_page_description=Specify the language conf
 SelectLanguageConfigurationWizardPage_page_title=Specify the language configuration file
 SelectLanguageConfigurationWizardPage_workspace_description=Language Configuration File:
 SelectLanguageConfigurationWizardPage_workspace_title=Select Language configuration file
+
+ToggleLineCommentHandler_ReadOnlyEditor_title=Read-only File Encountered
+ToggleLineCommentHandler_ReadOnlyEditor_inputReadonly=Editor input ''{0}'' is read-only.
+ToggleLineCommentHandler_ReadOnlyEditor_fileReadonly=File ''{0}'' is read-only.\n\nDo you wish to make it writable?
+ToggleLineCommentHandler_ReadOnlyEditor_makingWritableFailed=Could not make ''{0}'' writable:\n\n{1}


### PR DESCRIPTION
This addresses #789 similar to how `org.eclipse.team.ui` is dealing with edit attempts on read-only files, by prompting the user to make the file writeable.

![image](https://github.com/user-attachments/assets/7c49f629-68d8-463e-81a1-ba362f534e69)
