### PR TITLE
fix(languageconfiguration): support object-form line comments

### DIFF
--- a/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/model/LanguageConfiguration.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/main/java/org/eclipse/tm4e/languageconfiguration/internal/model/LanguageConfiguration.java
@@ -125,9 +125,14 @@ public final class LanguageConfiguration {
 						return null;
 					}
 
-					// ex: {"lineComment": "//","blockComment": [ "/*", "*/" ]}
 					final var jsonObj = json.getAsJsonObject();
-					final var lineComment = getAsString(jsonObj.get("lineComment")); //$NON-NLS-1$
+					final var lineCommentElem = jsonObj.get("lineComment"); //$NON-NLS-1$
+					// VS Code also permits {"comment":"#","noIndent":true} here.
+					// TM4E always inserts line comments at the start of the line, so noIndent
+					// currently has no effect and is intentionally ignored.
+					final var lineComment = lineCommentElem != null && lineCommentElem.isJsonObject()
+							? getAsString(lineCommentElem.getAsJsonObject().get("comment")) //$NON-NLS-1$
+							: getAsString(lineCommentElem);
 					final var blockCommentElem = jsonObj.get("blockComment"); //$NON-NLS-1$
 					CharacterPair blockComment = null;
 					if (blockCommentElem != null && blockCommentElem.isJsonArray()) {

--- a/org.eclipse.tm4e.languageconfiguration/src/test/java/org/eclipse/tm4e/languageconfiguration/internal/model/ParsingTest.java
+++ b/org.eclipse.tm4e.languageconfiguration/src/test/java/org/eclipse/tm4e/languageconfiguration/internal/model/ParsingTest.java
@@ -95,6 +95,21 @@ class ParsingTest {
 	}
 
 	@Test
+	void testCanLoadObjectLineComment() {
+		final var languageConfiguration = loadLanguageConfigFromString("""
+			{
+				"comments": {
+					"lineComment": {
+						"comment": "#",
+						"noIndent": true
+					}
+				}
+			}""");
+
+		assertThat(castNonNull(languageConfiguration.getComments()).lineComment).isEqualTo("#");
+	}
+
+	@Test
 	void testLanguagePackLangConfigs() throws IOException {
 		final var count = new AtomicInteger();
 		Files.walkFileTree(Paths.get("../org.eclipse.tm4e.language_pack"), new SimpleFileVisitor<Path>() {


### PR DESCRIPTION
Parse language configurations with object-form line comments without logging errors.

This PR fixes #1015 
